### PR TITLE
Using keywords in the instructions

### DIFF
--- a/src/Instructions/ConvertingFiguresToExamples.md
+++ b/src/Instructions/ConvertingFiguresToExamples.md
@@ -7,7 +7,7 @@ There is an ongoing effort to convert the examples in the [VTK Book](http://www.
 1. Follow the procedure [ForDevelopers](../ForDevelopers) to contribute examples.
 2. Download a copy of the [VTK Book](http://www.kitware.com/products/books/VTKTextbook.pdf).
 3. Look at the [VTKBookFigures](../../VTKBookFigures) page and look for examples that have not been converted. These examples will not have a link to source code.
-4. Go to your VTK source checkout. Run the script [VTKExamples/src/Admin/getDeletedFile.sh](https://github.com/ajpmaclean/VTKEx/blob/master/src/Admin/getDeletedFile.sh) with the name of the source file (e.g. walkCow.tcl) in the figure example to be converted. This script will create a source file in the current directory and also report the URL for the original repo location of the example.
+4. Go to your VTK source checkout. Run the script [getDeletedFile.sh](__BLOB__/src/Admin/getDeletedFile.sh), found in `src/Admin` folder, with the name of the source file (e.g. walkCow.tcl) in the figure example to be converted. This script will create a source file in the current directory and also report the URL for the original repo location of the example.
 5. Pick a source directory to contain the new example. Look at the Chapter heading in the book to guide where to put the new example.
 6. Convert the source tcl code or old C++ code to C++ code that will compile and run with the current VTK API. Follow the [guidelines for coding C++ examples](../Guidelines).
 7. If the figure example name is short, e.g. bluntStr we suggest giving it a more descriptive name e.g. BluntStreamlines. Notice the first letter is uppercase.
@@ -15,4 +15,4 @@ There is an ongoing effort to convert the examples in the [VTK Book](http://www.
     1. In the first column of the table, add a link from the Figure to the source code.
     2. In the second column of the table, add the VTK classes that are illustrated by the example.
     3. In the third column, cut and paste the caption from the VTK Book.
-    4. If there is a source file mentioned in the caption, make link to the original code URL printed by the *getDeletedFile.sh* script.
+    4. If there is a source file mentioned in the caption, make link to the original code URL printed by the [getDeletedFile.sh](__BLOB__/src/Admin/getDeletedFile.sh) script.

--- a/src/Instructions/ForAdministrators.md
+++ b/src/Instructions/ForAdministrators.md
@@ -1,10 +1,10 @@
 ## Administrators
 
-Administrators have write access to the [git repository](https://github.com/ajpmaclean/VtkEx). If you are a  User [go here](../ForUsers) or a  Developer [go here](../ForDevelopers).
+Administrators have write access to the [git repository](__REPOSITORY__). If you are a  User [go here](../ForUsers) or a  Developer [go here](../ForDevelopers).
 
 ## Organization of the Repository
 
-The  are stored in a [git repository](https://github.com/ajpmaclean/VtkEx.git) hosted at [github.com](http://www.github.com/). The repository contains several types of files.
+The files are stored in a [git repository](__REPOSITORY__) hosted at [github.com](http://www.github.com/). The repository contains several types of files.
 
 All example source code, descriptions, test data, and test baselines are stored in the *src/* tree.
 
@@ -49,9 +49,9 @@ The major elements of the tree are:
 
 ## Look and Feel
 
-A priority in moving from the wiki media [VTK Wiki Examples](http://www.vtk.org/Wiki/VTK/Examples) to the Github pages [VtkEx](https://ajpmaclean.github.io/VtkEx/site/) was to provide a modern, familiar look and feel. We also wanted to support tablet and mobile platforms. We chose [MkDocs](http://www.mkdocs.org/) because it generated static HTML pages that can be hosted anywhere.
+A priority in moving from the wiki media [VTK Wiki Examples](http://www.vtk.org/Wiki/VTK/Examples) to the Github pages [VTK Examples](__REPOSITORY__/site/) was to provide a modern, familiar look and feel. We also wanted to support tablet and mobile platforms. We chose [MkDocs](http://www.mkdocs.org/) because it generated static HTML pages that can be hosted anywhere.
 
-<img style="border:2px solid beige;float:center" src="https://github.com/ajpmaclean/VTKEx/blob/master/src/Artifacts/OldVersusNew.png?raw=true" />
+<img style="border:2px solid beige;float:center" src="__BLOB__/src/Artifacts/OldVersusNew.png?raw=true" />
 
 ### [MkDocs](http://www.mkdocs.org/)
 
@@ -68,10 +68,10 @@ pip install mkdocs
 The *mkdocs.yml* file contains the configuration parameters
 
 ```bash
-site_name: VTKEx
-site_url: https://ajpmaclean.github.io/VTKEx/site/
-repo_name: ajpmaclean/VTKEx
-repo_url: https://github.com/ajpmaclean/VTKEx
+site_name: __REPO_NAME__
+site_url: https://__USER_NAME__.github.io/__REPO_NAME__/site/
+repo_name: __USER_NAME__/__REPO_NAME__
+repo_url: __REPOSITORY__
 
 theme:
     name: material
@@ -166,7 +166,7 @@ Google Analytics tracks the site usage, providing lots of useful statistics. To 
 
 ### Configuring Google Analytics
 
-The *google_analytics* keyword in the *mkdocs.yml" file specifies the google analytics unique code for this web site. The *custom_theme/main.html* file defines the metadata for the google site verification:
+The *google_analytics* keyword in the *mkdocs.yml* file specifies the google analytics unique code for this web site. The *custom_theme/main.html* file defines the metadata for the google site verification:
 
 ``` html
 <meta name="google-site-verification" content="8hi6AHNlzKOmFDV4W8tLmySODRzQvtqMEIfZdc3WTLA" />
@@ -191,7 +191,7 @@ The overall look and feel are established at [https://cse.google.com/cse/](https
 
 ### Configuring GCSE
 
-The code is added to [custom_theme/main.html](https://github.com/ajpmaclean/VtkEx/blob/master/custom_theme/main.html).
+The code is added to [custom_theme/main.html](__BLOB_/custom_theme/main.html).
 
 ``` html
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
@@ -210,7 +210,7 @@ The search box is added to the web pages by adding the gcse search box html
 
 ### [Lazy Image Loading](https://davidwalsh.name/lazyload-image-fade)
 
-The first implementation had problems loading the [Cxx summary](https://ajpmaclean.github.io/VTKEx/site/Cxx/). The number of embedded images exceeded the throttle limits of Github. A lazy image load solution solved the problem. Now, images are only loaded if they appear in the browser window.
+The first implementation had problems loading the [Cxx summary](__REPOSITORY__/site/Cxx/). The number of embedded images exceeded the throttle limits of Github. A lazy image load solution solved the problem. Now, images are only loaded if they appear in the browser window.
 
 The Lazy Image Loading is implemented in javascript. The javascript is stored in *custom_theme/main.html*. It uses a clever *trick*. Images that should be lazy loaded use a *<img>* tag with a *class=lazy* and attribute *data_src*. If the image is in the viewport, the *data_src* is removed, and the image renders.
 
@@ -218,7 +218,7 @@ The Lazy Image Loading is implemented in javascript. The javascript is stored in
 
 The  web pages have many URL's that link to images and VTK doxygen pages. The long length of these URLs can increase page load times, especially on the language summary pages. 
 
-[http://tinyurl.com](http://tinyurl.com) provides a service to map the long URL's into shorted URLs. To speed up the process, we cache the long/short URLs in a file [src/Cache/TestImages.cache](https://github.com/ajpmaclean/VtkEx/raw/master/src/Cache/TestImages.cache). *ScrapeRepo.py* uses this cache to only convert URLs that are not in the cache. *ScrapeRepo.py* updates the cache after each run.
+[http://tinyurl.com](http://tinyurl.com) provides a service to map the long URL's into shorted URLs. To speed up the process, we cache the long/short URLs in a file [src/Cache/TestImages.cache](__REPOSITORY__/raw/master/src/Cache/TestImages.cache). *ScrapeRepo.py* uses this cache to only convert URLs that are not in the cache. *ScrapeRepo.py* updates the cache after each run.
 
 ### Minify HTML pages
 
@@ -232,9 +232,9 @@ pip install htmlmin
 
 ## Administrator Tasks
 
-### [ScrapeRepo.py](https://github.com/ajpmaclean/VtkEx/blob/master/src/Admin/ScrapeRepo.py)
+### [ScrapeRepo.py](__BLOB__/src/Admin/ScrapeRepo.py)
 
-<img style="border:2px solid beige;float:center" src="https://github.com/ajpmaclean/VtkEx/blob/master/src/Artifacts/ScrapeRepo.png?raw=true" />
+<img style="border:2px solid beige;float:center" src="__BLOB__/src/Artifacts/ScrapeRepo.png?raw=true" />
 
 Given a *SiteDir*, *DocDir*, *RepositoryDir* and a *RepositoryUrl*, *ScrapeRepo* proceeds as follows:
 
@@ -258,21 +258,21 @@ The *SyncSiteWithRepo.sh* shell script executes all of the steps to update the s
 
 1. Makes sure the site is up
 
-2. Pulls updates from the [master repository](https://github.com/ajpmaclean/VtkEx).
+2. Pulls updates from the [master repository](__REPOSITORY__).
 
-3. Pulls updates from the [src/Tarballs repository](https://github.com/ajpmaclean/VTKEx/tree/master/src/Tarballs)
+3. Pulls updates from the [src/Tarballs repository](__TREE__/src/Tarballs)
 
      The tarballs should be kept in a separate repository to reduce the size of the main repository. They are only accessed from the individual example pages. Currently they are in the main repository.
 
 4. Creates the coverage files
 
-     The [src/Admin/VTKClassesUsedInExamples.py](https://github.com/ajpmaclean/VtkEx/blob/master/src/Admin/VTKClassesUsedInExamples.py) python script generates two tables for each language. One table list each class and what classes it uses. The second table lists the classes that are not used in any example.
+     The [src/Admin/VTKClassesUsedInExamples.py](__BLOB__/src/Admin/VTKClassesUsedInExamples.py) python script generates two tables for each language. One table list each class and what classes it uses. The second table lists the classes that are not used in any example.
 
 5. Wipes the *docs* directory
 
      The *docs* directory contains all of the md and HTML files for the site. A clean directory prevents old files from being used.
 
-6. Runs the [ScrapeRepo script](https://github.com/ajpmaclean/VtkEx/blob/master/src/Admin/ScrapeRepo.py)
+6. Runs the [ScrapeRepo script](__BLOB__/src/Admin/ScrapeRepo.py)
 
      populate the *docs* directory.
 
@@ -284,7 +284,7 @@ The *SyncSiteWithRepo.sh* shell script executes all of the steps to update the s
 
 9. Copies the sitemap.xml file
 
-     This file is updated periodically by [sitemapGenerator](https://github.com/ajpmaclean/VtkEx/blob/master/src/Admin/sitemapGenerator.sh)
+     This file is updated periodically by [sitemapGenerator](__BLOB__/src/Admin/sitemapGenerator.sh)
 
 10. Minify the HTML
 

--- a/src/Instructions/ForDevelopers.md
+++ b/src/Instructions/ForDevelopers.md
@@ -18,7 +18,7 @@ Some additional steps need to be done for Python C# and Java, see the sections b
 
     If you do not have an account, you can register on the sign-in page.
 
-2. Fork the [VTKEx repository](https://github.com/ajpmaclean/VTKEx)
+2. Fork the VTK examples [repository](__REPOSITORY__)
 
     A fork is a copy of a project. Forking a repository allows you to make changes without affecting the original project.
 
@@ -29,24 +29,24 @@ Some additional steps need to be done for Python C# and Java, see the sections b
 4. Clone the repository on your local machine
 
 ``` bash
-    git clone https://YOURNAME@github.com/YOURNAME/VTKEx.git
+    git clone https://YOURNAME@github.com/YOURNAME/__REPO_NAME__.git
 ```
 
    Or, if you are using SSH:
 
 ``` bash
-    git clone git@github.com:YOURNAME/VTKEx.git
+    git clone git@github.com:YOURNAME/__REPO_NAME__.git
 ```
 
    where **YOURNAME** is your GitHub username.
 
-5. Add the VTKEx repository as a *remote* called *upstream*
+5. Add the __REPO_NAME__ repository as a *remote* called *upstream*
 
 ``` bash
-    git remote add upstream https://github.com/ajpmaclean/VTKEx
+    git remote add upstream __REPOSITORY__
 ```
 
-6. Before adding your examples, sync your repository with the VTKEx repository. Remember that to run the following commands, you need to be in the **VTKEx** directory.
+6. Before adding your examples, sync your repository with the __REPO_NAME__ repository. Remember that to run the following commands, you need to be in the **__REPO_NAME__** directory.
 
 ``` bash
     git fetch upstream
@@ -55,10 +55,10 @@ Some additional steps need to be done for Python C# and Java, see the sections b
     git push
 ```
 
-7. Build the VTKEx code
+7. Build the __REPO_NAME__ code
 
 ``` bash
-    cd VTKEx
+    cd __REPO_NAME__
     cd build
     cmake -DVTK_DIR:PATH=YOUR_VTK_BIN_DIR -DBUILD_TESTING:BOOL=ON ..
     make
@@ -91,7 +91,7 @@ DataStructures, Filters, GeometricObjects, Images, Meshes, etc.
     - [Python available snippets](../../Python/Snippets).
     - [Java available snippets](../../Java/Snippets).
 
-3. Save your source code in VTKEx/src/**LANGUAGE**/**TOPIC**/
+3. Save your source code in __REPO_NAME__/src/**LANGUAGE**/**TOPIC**/
 
     where **LANGUAGE** is Cxx, Python, CSharp or Java.
 
@@ -102,7 +102,7 @@ DataStructures, Filters, GeometricObjects, Images, Meshes, etc.
    - for Cxx
 
 ``` bash
-        cd VTKEx/build
+        cd __REPO_NAME__/build
         cmake ..
         make
         ctest -V -R MyNewExample
@@ -114,9 +114,9 @@ Note: If **MyNewExample** is not built, then in the directory where you put the 
     touch CMakeLists.txt
 ```
 
-5. If your C++ example does any rendering, the test will fail the first time and create an image in VTKEx/build/Testing/Temporary. The image will be called Test**MyNewExample**.png.
+5. If your C++ example does any rendering, the test will fail the first time and create an image in __REPO_NAME__/build/Testing/Temporary. The image will be called Test**MyNewExample**.png.
 
-6. Copy the image into: VTKEx/src/Testing/Baseline/**LANG**/**TOPIC**/. For Python and other languages, create an image with the proper name using a screen capture and copy that image into the proper location.
+6. Copy the image into: __REPO_NAME__/src/Testing/Baseline/**LANG**/**TOPIC**/. For Python and other languages, create an image with the proper name using a screen capture and copy that image into the proper location.
 
 7. Rerun ctest and the test should pass.
 
@@ -207,8 +207,8 @@ If you want to preview your changes in a browser (**NOTE:** You must have Python
   3. Sync your site with your repository with a command like this:
 
 ``` bash
-        ./src/SyncSiteWithRepo.sh https://github.com/**github_username**/VTKEx /home/**username**/**path_to**/VTK/
-        ./src/SyncSiteWithRepo.sh https::/github.com/**YOUR_NAME**/VTKEx
+        ./src/SyncSiteWithRepo.sh https://github.com/**github_username**/__REPO_NAME__ /home/**username**/**path_to**/VTK/
+        ./src/SyncSiteWithRepo.sh https::/github.com/**YOUR_NAME**/__REPO_NAME__
 ```
 
-  4. After a few minutes go to https://**github_username**.github.io/VTKEx/ to see your changes before issuing your pull request.
+  4. After a few minutes go to https://**github_username**.github.io/__REPO_NAME__/ to see your changes before issuing your pull request.

--- a/src/Instructions/ForUsers.md
+++ b/src/Instructions/ForUsers.md
@@ -1,6 +1,6 @@
 ## Users
 
-If you want to use [VTK Ex](https://github.com/ajpmaclean/VTKEx), you have several options. If you are a VTK Example Developer, [go here](../ForDevelopers) or a VTK Example Administrator [go here](../ForAdministrators).
+If you want to use the examples [repository](__REPOSITORY__), you have several options. If you are a VTK Example Developer, [go here](../ForDevelopers) or a VTK Example Administrator [go here](../ForAdministrators).
 
 ## Build an example
 
@@ -13,15 +13,15 @@ downloading individual examples, you can build them all.
 
 1. As a VTK Remote module
 
-   When you configure your VTK build, set Module_VTKEx:BOOL=ON and rebuild VTK.
+   When you configure your VTK build, set Module___REPO_NAME__:BOOL=ON and rebuild VTK.
 
-2. Download a [zip](https://github.com/ajpmaclean/VTKEx/archive/master.zip) containing the source.
+2. Download a [zip](__ARCHIVE__) containing the source.
 
 3. Clone the VTK examples repository
 
 ``` bash
-   git clone https://github.com/ajpmaclean/VTKEx.git
-   cd VTKEx
+   git clone __GIT_REPO__
+   cd __REPO_NAME__
    cd build
    cmake -DVTK_DIR:PATH=YOUR_VTK_BIN_DIR -DBUILD_TESTING:BOOL=ON ..
    make
@@ -34,10 +34,10 @@ downloading individual examples, you can build them all.
 If you cloned the examples repository, you can get the latest updates:
 
 ``` bash
-cd VTKEx
+cd __REPO_NAME__
 git pull
 cd build
-cmake ../VTKEx
+cmake ../__REPO_NAME__
 make
 ```
 

--- a/src/Instructions/Guidelines.md
+++ b/src/Instructions/Guidelines.md
@@ -4,7 +4,7 @@ Although education of new users is the main motivation, the VTK Examples should 
 
 1. Encourage good programming style
 2. Promote the proper and modern way to use VTK and write VTK programs
-3. Facilitate the nightly compilation and testing of examples that reside in the VTKExamples repository.
+3. Facilitate the nightly compilation and testing of examples that reside in the VTK Examples repository.
 
 These requirements must be met without compromising the main goal of user education.
 
@@ -14,7 +14,7 @@ All examples should follow the VTK programming style and there should be a singl
 
 ### C++
 
-* The indentation style can be characterized as the [AllmannStyle](https://en.wikipedia.org/wiki/Indent_style#Allman_style). The curly brace (scope delimiter) is on a separate line and aligns with the control statement, The control block is indented by two spaces (**no tabs**). A suitable `.clang-format` is provided in `src/Cxx` [see here](https://github.com/ajpmaclean/VtkEx/blob/master/src/Cxx/.clang-format).
+* The indentation style can be characterized as the [AllmannStyle](https://en.wikipedia.org/wiki/Indent_style#Allman_style). The curly brace (scope delimiter) is on a separate line and aligns with the control statement, The control block is indented by two spaces (**no tabs**). A suitable `.clang-format` is provided in `src/Cxx` [see here](__BLOB__/src/Cxx/.clang-format).
 
     Example:
 
@@ -122,7 +122,7 @@ All examples should follow the VTK programming style and there should be a singl
 
 * Always provide a background for the renderers. Avoid setting the background to white.
 
-* Use [vtkNamedColors](http://www.vtk.org/doc/nightly/html/classvtkNamedColors.html) for setting colors of actors and renderer backgrounds. [VTKNamedColorPatches](http://htmlpreview.github.io/?https://github.com/ajpmaclean/VTKEx/blob/master/VTKNamedColorPatches.html) shows the colors that are available. If you are using a color series, then you can choose what you want from here [VTKColorSeriesPatches](http://htmlpreview.github.io/?https://github.com/ajpmaclean/VTKEx/blob/master/VTKColorSeriesPatches.html).
+* Use [vtkNamedColors](http://www.vtk.org/doc/nightly/html/classvtkNamedColors.html) for setting colors of actors and renderer backgrounds. [VTKNamedColorPatches](http://htmlpreview.github.io/?__BLOB__/VTKNamedColorPatches.html) shows the colors that are available. If you are using a color series, then you can choose what you want from here [VTKColorSeriesPatches](http://htmlpreview.github.io/?__BLOB__/VTKColorSeriesPatches.html).
 
     For example,
 
@@ -141,7 +141,7 @@ All examples should follow the VTK programming style and there should be a singl
         renderer->SetBackground(0.9412, 0.9020, 0.5490);
     ```
 
-* Use admonitions to warn/cite/info, etc. [Here is a summary of admonitions](https://ajpmaclean.github.io/VTKEx/site/Instructions/ForAdministrators/#admonition).
+* Use admonitions to warn/cite/info, etc. [Here is a summary of admonitions](__SITE__/Instructions/ForAdministrators/#admonition).
 
 ### Python
 
@@ -170,13 +170,13 @@ if __name__ == '__main__':
 
 * Input/Output filenames and parameters.
 
-    Use this snippet [GetProgramParameters](https://ajpmaclean.github.io/VTKEx/site/Python/Snippets/GetProgramParameters/) 
+    Use this snippet [GetProgramParameters](__SITE__/Python/Snippets/GetProgramParameters/) 
 
 ### Java
 
 In general, Java submissions should follow the VTK Programming style and the comments outlined for C++ above (with language appropriate modification).
 
-For Java code layout, look at [CylinderExample](https://ajpmaclean.github.io/VTKEx/site/Java/GeometricObjects/CylinderExample/)
+For Java code layout, look at [CylinderExample](__SITE__/Java/GeometricObjects/CylinderExample/)
 
 Java code styling follows the usual style as implemented in the IDEs.
 


### PR DESCRIPTION
The correct paths etc. are substituted for these when building the markdown pages.